### PR TITLE
Support broker to receive context from parent

### DIFF
--- a/broker/internals/notifier.go
+++ b/broker/internals/notifier.go
@@ -60,7 +60,11 @@ func (s *Notifier) NotifyNews(ctx context.Context) {
 							subscription.SubscribeChan <- true
 						} else {
 							go func() {
-								s.subscriptionChan <- subscription
+								select {
+								case <- ctx.Done():
+									return
+								case s.subscriptionChan <- subscription:
+								}
 							}()
 						}
 					} else {

--- a/broker/internals/topic.go
+++ b/broker/internals/topic.go
@@ -1,18 +1,16 @@
 package internals
 
 import (
-	"sync"
 	"sync/atomic"
 )
 
 type Topic struct {
 	name                   string
-	Size, NumPubs, NumSubs uint64
-	published              *sync.Cond
+	Size, NumPubs, NumSubs int64
 }
 
 func NewTopic(topicName string) *Topic {
-	return &Topic{topicName, 0, 0, 0, sync.NewCond(&sync.Mutex{})}
+	return &Topic{topicName, 0, 0, 0}
 }
 
 func (t Topic) Name() string {
@@ -20,9 +18,9 @@ func (t Topic) Name() string {
 }
 
 func (t *Topic) LastOffset() uint64 {
-	size := atomic.LoadUint64(&t.Size)
+	size := atomic.LoadInt64(&t.Size)
 	if size == 0 {
 		return 0
 	}
-	return size - 1
+	return uint64(size - 1)
 }

--- a/broker/pipeline/connect_pipe.go
+++ b/broker/pipeline/connect_pipe.go
@@ -67,9 +67,9 @@ func (c *ConnectPipe) Ready(ctx context.Context, inStream <-chan interface{}, wg
 
 			switch req.SessionType {
 			case paustq_proto.SessionType_PUBLISHER:
-				atomic.AddUint64(&c.session.Topic().NumPubs, 1)
+				atomic.AddInt64(&c.session.Topic().NumPubs, 1)
 			case paustq_proto.SessionType_SUBSCRIBER:
-				atomic.AddUint64(&c.session.Topic().NumSubs, 1)
+				atomic.AddInt64(&c.session.Topic().NumSubs, 1)
 			default:
 			}
 

--- a/broker/pipeline/put_pipe.go
+++ b/broker/pipeline/put_pipe.go
@@ -57,7 +57,7 @@ func (p *PutPipe) Ready(ctx context.Context, inStream <-chan interface{}, wg *sy
 
 			req := in.(*paustq_proto.PutRequest)
 
-			savedOffset := atomic.AddUint64(&topic.Size, 1) - 1
+			savedOffset := uint64(atomic.AddInt64(&topic.Size, 1) - 1)
 			err := p.db.PutRecord(topic.Name(), savedOffset, req.Data)
 
 			if err != nil {

--- a/client/cli/connection.go
+++ b/client/cli/connection.go
@@ -19,13 +19,13 @@ func NewHeartbeatCmd() *cobra.Command {
 		Short: "Send heartbeat to broker",
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := context.Background()
-			apiClient := client.NewAPIClient(ctx, bootstrapServer)
+			apiClient := client.NewAPIClient(bootstrapServer)
 			defer apiClient.Close()
 
 			if apiClient.Connect() != nil {
 				log.Fatal("cannot connect to broker")
 			}
-			pongMsg, err := apiClient.Heartbeat(echoMsg, brokerId)
+			pongMsg, err := apiClient.Heartbeat(ctx, echoMsg, brokerId)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/integration_test/pubsub_test.go
+++ b/integration_test/pubsub_test.go
@@ -28,9 +28,18 @@ func TestClient_Connect(t *testing.T) {
 
 	// Start broker
 	brokerInstance := broker.NewBroker(uint16(port))
-	go brokerInstance.Start()
 	defer brokerInstance.Clean()
-	defer brokerInstance.Stop()
+
+	brokerCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		err := brokerInstance.Start(brokerCtx)
+		if err != nil {
+			t.Error("error on starting broker")
+			return
+		}
+	}()
 
 	time.Sleep(1 * time.Second)
 
@@ -67,9 +76,18 @@ func TestPubSub(t *testing.T) {
 
 	// Start broker
 	brokerInstance := broker.NewBroker(uint16(port))
-	go brokerInstance.Start()
 	defer brokerInstance.Clean()
-	defer brokerInstance.Stop()
+
+	brokerCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		err := brokerInstance.Start(brokerCtx)
+		if err != nil {
+			t.Error("error on starting broker")
+			return
+		}
+	}()
 
 	time.Sleep(1 * time.Second)
 
@@ -132,12 +150,20 @@ func TestPubsub_Chunk(t *testing.T) {
 	host := fmt.Sprintf("%s:%d", ip, port)
 	ctx1 := context.Background()
 	ctx2 := context.Background()
+	brokerCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	// Start broker
 	brokerInstance := broker.NewBroker(uint16(port))
-	go brokerInstance.Start()
 	defer brokerInstance.Clean()
-	defer brokerInstance.Stop()
+
+	go func() {
+		err := brokerInstance.Start(brokerCtx)
+		if err != nil {
+			t.Error("error on starting broker")
+			return
+		}
+	}()
 
 	time.Sleep(1 * time.Second)
 
@@ -216,11 +242,19 @@ func TestMultiClient(t *testing.T) {
 
 	host := fmt.Sprintf("%s:%d", ip, port)
 
-	// Start broker
 	brokerInstance := broker.NewBroker(uint16(port))
-	go brokerInstance.Start()
 	defer brokerInstance.Clean()
-	defer brokerInstance.Stop()
+
+	brokerCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		err := brokerInstance.Start(brokerCtx)
+		if err != nil {
+			t.Error("error on starting broker")
+			return
+		}
+	}()
 
 	time.Sleep(1 * time.Second)
 


### PR DESCRIPTION
From this Pull Request,
* Broker have to receive context when it starts.
* When some session is closed, number of subscriber or number of publisher of session related topic will be decreased due to its session type.
* When Stop() method of broker is called, broker gonna stop gracefully
  * Stop accepting new connections and RPCs and blocks until pending RPCs are finished
  * Close database