### PR TITLE
Update ZKTargetAlreadyExistsError handling codes

### DIFF
--- a/broker/pipeline/connect_pipe.go
+++ b/broker/pipeline/connect_pipe.go
@@ -1,7 +1,6 @@
 package pipeline
 
 import (
-	"errors"
 	"github.com/paust-team/shapleq/broker/internals"
 	"github.com/paust-team/shapleq/message"
 	"github.com/paust-team/shapleq/pqerror"
@@ -83,7 +82,7 @@ func (c *ConnectPipe) Ready(inStream <-chan interface{}) (<-chan interface{}, <-
 			case shapleq_proto.SessionType_PUBLISHER:
 				atomic.AddInt64(&c.session.Topic().NumPubs, 1)
 				err := c.zkClient.AddTopicBroker(c.session.Topic().Name(), c.brokerAddr)
-				if err != nil && !errors.As(err, &pqerror.ZKTargetAlreadyExistsError{}) {
+				if err != nil {
 					errCh <- err
 					return
 				}

--- a/broker/service/rpc/topic.go
+++ b/broker/service/rpc/topic.go
@@ -1,7 +1,6 @@
 package rpc
 
 import (
-	"errors"
 	"github.com/paust-team/shapleq/broker/internals"
 	"github.com/paust-team/shapleq/broker/storage"
 	"github.com/paust-team/shapleq/message"
@@ -31,10 +30,6 @@ func (s topicRPCService) CreateTopic(request *shapleqproto.CreateTopicRequest) *
 	topicValue := internals.NewTopicMetaFromValues(request.Topic.Description, request.Topic.NumPartitions, request.Topic.ReplicationFactor)
 	err := s.zkClient.AddTopic(request.Topic.Name, topicValue)
 	if err != nil {
-		var e pqerror.ZKTargetAlreadyExistsError
-		if errors.As(err, &e) {
-			return message.NewCreateTopicResponseMsg(e)
-		}
 		return message.NewCreateTopicResponseMsg(&pqerror.ZKOperateError{ErrStr: err.Error()})
 	}
 

--- a/zookeeper/zk_client.go
+++ b/zookeeper/zk_client.go
@@ -108,11 +108,12 @@ func (z *ZKClient) AddTopic(topic string, topicMeta *internals.TopicMeta) error 
 	_, err = z.conn.Create(topicPath(topic), topicMeta.Data(), 0, zk.WorldACL(zk.PermAll))
 	if err != nil {
 		if err == zk.ErrNodeExists {
-			err = pqerror.ZKTargetAlreadyExistsError{Target: topicPath(topic)}
+			z.logger.Info(pqerror.ZKTargetAlreadyExistsError{Target: topicPath(topic)})
+			return nil
 		} else {
-			err = pqerror.ZKRequestError{ZKErrStr: err.Error()}
+			z.logger.Error(pqerror.ZKRequestError{ZKErrStr: err.Error()})
 		}
-		z.logger.Error(err)
+
 		return err
 	}
 	return nil
@@ -321,9 +322,8 @@ func (z *ZKClient) AddTopicBroker(topic string, server string) error {
 
 	for _, topicBroker := range topicBrokers {
 		if topicBroker == server {
-			err = pqerror.ZKTargetAlreadyExistsError{Target: server}
-			z.logger.Error(err)
-			return err
+			z.logger.Info(pqerror.ZKTargetAlreadyExistsError{Target: server})
+			return nil
 		}
 	}
 


### PR DESCRIPTION
Update broker code to not to handle ZKTargetAlreadyExistsError as an error type

close #77 